### PR TITLE
[quality] Fix quality rule 'boundaries should not overlap'

### DIFF
--- a/asistente_ladm_col/lib/geometry.py
+++ b/asistente_ladm_col/lib/geometry.py
@@ -264,8 +264,8 @@ class GeometryUtils(QObject):
         feedback = QgsProcessingFeedback()
         dict_res = processing.run("model:Overlapping_Boundaries", {
                     'Boundary':line_layer,
-                    'native:saveselectedfeatures_2:Intersected_Lines':'memory:',
-                    'native:saveselectedfeatures_3:Intersected_Points':'memory:'
+                    'native:extractbyexpression_3:Intersected_Lines':'memory:',
+                    'native:extractbyexpression_2:Intersected_Points':'memory:'
                 },
                 feedback=feedback)
 

--- a/asistente_ladm_col/lib/processing/models/model_overlapping_boundaries.model3
+++ b/asistente_ladm_col/lib/processing/models/model_overlapping_boundaries.model3
@@ -1,412 +1,591 @@
 <!DOCTYPE model>
 <Option type="Map">
   <Option type="Map" name="children">
-    <Option type="Map" name="native:difference_1">
-      <Option value="true" type="bool" name="active"/>
+    <Option type="Map" name="native:createspatialindex_1">
+      <Option type="bool" value="true" name="active"/>
       <Option name="alg_config"/>
-      <Option value="native:difference" type="QString" name="alg_id"/>
-      <Option value="Intersected_Points" type="QString" name="component_description"/>
-      <Option value="779" type="double" name="component_pos_x"/>
-      <Option value="573" type="double" name="component_pos_y"/>
+      <Option type="QString" value="native:createspatialindex" name="alg_id"/>
+      <Option type="QString" value="" name="color"/>
+      <Option type="Map" name="comment">
+        <Option type="QString" value="" name="color"/>
+        <Option type="QString" value="" name="component_description"/>
+        <Option type="double" value="60" name="component_height"/>
+        <Option type="double" value="737.211234865009" name="component_pos_x"/>
+        <Option type="double" value="295.90697911734406" name="component_pos_y"/>
+        <Option type="double" value="100" name="component_width"/>
+        <Option type="bool" value="true" name="outputs_collapsed"/>
+        <Option type="bool" value="true" name="parameters_collapsed"/>
+      </Option>
+      <Option type="QString" value="Create spatial index" name="component_description"/>
+      <Option type="double" value="30" name="component_height"/>
+      <Option type="double" value="542.0582535254451" name="component_pos_x"/>
+      <Option type="double" value="316.6718858151632" name="component_pos_y"/>
+      <Option type="double" value="200" name="component_width"/>
       <Option name="dependencies"/>
-      <Option value="native:difference_1" type="QString" name="id"/>
+      <Option type="QString" value="native:createspatialindex_1" name="id"/>
       <Option name="outputs"/>
-      <Option value="true" type="bool" name="outputs_collapsed"/>
-      <Option value="true" type="bool" name="parameters_collapsed"/>
+      <Option type="bool" value="true" name="outputs_collapsed"/>
+      <Option type="bool" value="true" name="parameters_collapsed"/>
       <Option type="Map" name="params">
         <Option type="List" name="INPUT">
           <Option type="Map">
-            <Option value="native:lineintersections_1" type="QString" name="child_id"/>
-            <Option value="OUTPUT" type="QString" name="output_name"/>
-            <Option value="1" type="int" name="source"/>
+            <Option type="QString" value="native:lineintersections_1" name="child_id"/>
+            <Option type="QString" value="OUTPUT" name="output_name"/>
+            <Option type="int" value="1" name="source"/>
           </Option>
         </Option>
-        <Option type="List" name="OVERLAY">
+      </Option>
+    </Option>
+    <Option type="Map" name="native:extractbyexpression_1">
+      <Option type="bool" value="true" name="active"/>
+      <Option name="alg_config"/>
+      <Option type="QString" value="native:extractbyexpression" name="alg_id"/>
+      <Option type="QString" value="" name="color"/>
+      <Option type="Map" name="comment">
+        <Option type="QString" value="" name="color"/>
+        <Option type="QString" value="" name="component_description"/>
+        <Option type="double" value="60" name="component_height"/>
+        <Option type="double" value="1352.0672436751" name="component_pos_x"/>
+        <Option type="double" value="256.76098535286286" name="component_pos_y"/>
+        <Option type="double" value="100" name="component_width"/>
+        <Option type="bool" value="true" name="outputs_collapsed"/>
+        <Option type="bool" value="true" name="parameters_collapsed"/>
+      </Option>
+      <Option type="QString" value="Extract vertices by expression" name="component_description"/>
+      <Option type="double" value="30" name="component_height"/>
+      <Option type="double" value="777.6169847216584" name="component_pos_x"/>
+      <Option type="double" value="317.81922106521085" name="component_pos_y"/>
+      <Option type="double" value="200" name="component_width"/>
+      <Option name="dependencies"/>
+      <Option type="QString" value="native:extractbyexpression_1" name="id"/>
+      <Option name="outputs"/>
+      <Option type="bool" value="true" name="outputs_collapsed"/>
+      <Option type="bool" value="true" name="parameters_collapsed"/>
+      <Option type="Map" name="params">
+        <Option type="List" name="EXPRESSION">
           <Option type="Map">
-            <Option value="native:saveselectedfeatures_1" type="QString" name="child_id"/>
-            <Option value="OUTPUT" type="QString" name="output_name"/>
-            <Option value="1" type="int" name="source"/>
+            <Option type="int" value="2" name="source"/>
+            <Option type="QString" value="&quot;t_id&quot; &lt; &quot;t_id_2&quot;" name="static_value"/>
+          </Option>
+        </Option>
+        <Option type="List" name="INPUT">
+          <Option type="Map">
+            <Option type="QString" value="native:intersection_2" name="child_id"/>
+            <Option type="QString" value="OUTPUT" name="output_name"/>
+            <Option type="int" value="1" name="source"/>
+          </Option>
+        </Option>
+      </Option>
+    </Option>
+    <Option type="Map" name="native:extractbyexpression_2">
+      <Option type="bool" value="true" name="active"/>
+      <Option name="alg_config"/>
+      <Option type="QString" value="native:extractbyexpression" name="alg_id"/>
+      <Option type="QString" value="" name="color"/>
+      <Option type="Map" name="comment">
+        <Option type="QString" value="" name="color"/>
+        <Option type="QString" value="" name="component_description"/>
+        <Option type="double" value="60" name="component_height"/>
+        <Option type="double" value="1415.5958721704394" name="component_pos_x"/>
+        <Option type="double" value="604.9467376830893" name="component_pos_y"/>
+        <Option type="double" value="100" name="component_width"/>
+        <Option type="bool" value="true" name="outputs_collapsed"/>
+        <Option type="bool" value="true" name="parameters_collapsed"/>
+      </Option>
+      <Option type="QString" value="Extract by expression" name="component_description"/>
+      <Option type="double" value="30" name="component_height"/>
+      <Option type="double" value="665.4472423733389" name="component_pos_x"/>
+      <Option type="double" value="470.9233773645626" name="component_pos_y"/>
+      <Option type="double" value="200" name="component_width"/>
+      <Option name="dependencies"/>
+      <Option type="QString" value="native:extractbyexpression_2" name="id"/>
+      <Option type="Map" name="outputs">
+        <Option type="Map" name="Intersected_Points">
+          <Option type="QString" value="native:extractbyexpression_2" name="child_id"/>
+          <Option type="QString" value="" name="color"/>
+          <Option type="Map" name="comment">
+            <Option type="QString" value="" name="color"/>
+            <Option type="QString" value="" name="component_description"/>
+            <Option type="double" value="60" name="component_height"/>
+            <Option type="double" value="0" name="component_pos_x"/>
+            <Option type="double" value="0" name="component_pos_y"/>
+            <Option type="double" value="100" name="component_width"/>
+            <Option type="bool" value="true" name="outputs_collapsed"/>
+            <Option type="bool" value="true" name="parameters_collapsed"/>
+          </Option>
+          <Option type="QString" value="Intersected_Points" name="component_description"/>
+          <Option type="double" value="30" name="component_height"/>
+          <Option type="double" value="667.3879033869365" name="component_pos_x"/>
+          <Option type="double" value="538.5265663655284" name="component_pos_y"/>
+          <Option type="double" value="200" name="component_width"/>
+          <Option type="invalid" name="default_value"/>
+          <Option type="bool" value="false" name="mandatory"/>
+          <Option type="QString" value="Intersected_Points" name="name"/>
+          <Option type="QString" value="OUTPUT" name="output_name"/>
+          <Option type="bool" value="true" name="outputs_collapsed"/>
+          <Option type="bool" value="true" name="parameters_collapsed"/>
+        </Option>
+      </Option>
+      <Option type="bool" value="true" name="outputs_collapsed"/>
+      <Option type="bool" value="true" name="parameters_collapsed"/>
+      <Option type="Map" name="params">
+        <Option type="List" name="EXPRESSION">
+          <Option type="Map">
+            <Option type="int" value="2" name="source"/>
+            <Option type="QString" value="&quot;t_id&quot; &lt; &quot;t_id_2&quot;" name="static_value"/>
+          </Option>
+        </Option>
+        <Option type="List" name="INPUT">
+          <Option type="Map">
+            <Option type="QString" value="native:extractbylocation_1" name="child_id"/>
+            <Option type="QString" value="OUTPUT" name="output_name"/>
+            <Option type="int" value="1" name="source"/>
+          </Option>
+        </Option>
+      </Option>
+    </Option>
+    <Option type="Map" name="native:extractbyexpression_3">
+      <Option type="bool" value="true" name="active"/>
+      <Option name="alg_config"/>
+      <Option type="QString" value="native:extractbyexpression" name="alg_id"/>
+      <Option type="QString" value="" name="color"/>
+      <Option type="Map" name="comment">
+        <Option type="QString" value="" name="color"/>
+        <Option type="QString" value="" name="component_description"/>
+        <Option type="double" value="60" name="component_height"/>
+        <Option type="double" value="568" name="component_pos_x"/>
+        <Option type="double" value="495" name="component_pos_y"/>
+        <Option type="double" value="100" name="component_width"/>
+        <Option type="bool" value="true" name="outputs_collapsed"/>
+        <Option type="bool" value="true" name="parameters_collapsed"/>
+      </Option>
+      <Option type="QString" value="Extract by expression" name="component_description"/>
+      <Option type="double" value="30" name="component_height"/>
+      <Option type="double" value="244" name="component_pos_x"/>
+      <Option type="double" value="319" name="component_pos_y"/>
+      <Option type="double" value="200" name="component_width"/>
+      <Option name="dependencies"/>
+      <Option type="QString" value="native:extractbyexpression_3" name="id"/>
+      <Option type="Map" name="outputs">
+        <Option type="Map" name="Intersected_Lines">
+          <Option type="QString" value="native:extractbyexpression_3" name="child_id"/>
+          <Option type="QString" value="" name="color"/>
+          <Option type="Map" name="comment">
+            <Option type="QString" value="" name="color"/>
+            <Option type="QString" value="" name="component_description"/>
+            <Option type="double" value="60" name="component_height"/>
+            <Option type="double" value="0" name="component_pos_x"/>
+            <Option type="double" value="0" name="component_pos_y"/>
+            <Option type="double" value="100" name="component_width"/>
+            <Option type="bool" value="true" name="outputs_collapsed"/>
+            <Option type="bool" value="true" name="parameters_collapsed"/>
+          </Option>
+          <Option type="QString" value="Intersected_Lines" name="component_description"/>
+          <Option type="double" value="30" name="component_height"/>
+          <Option type="double" value="248" name="component_pos_x"/>
+          <Option type="double" value="384" name="component_pos_y"/>
+          <Option type="double" value="200" name="component_width"/>
+          <Option type="invalid" name="default_value"/>
+          <Option type="bool" value="false" name="mandatory"/>
+          <Option type="QString" value="Intersected_Lines" name="name"/>
+          <Option type="QString" value="OUTPUT" name="output_name"/>
+          <Option type="bool" value="true" name="outputs_collapsed"/>
+          <Option type="bool" value="true" name="parameters_collapsed"/>
+        </Option>
+      </Option>
+      <Option type="bool" value="true" name="outputs_collapsed"/>
+      <Option type="bool" value="true" name="parameters_collapsed"/>
+      <Option type="Map" name="params">
+        <Option type="List" name="EXPRESSION">
+          <Option type="Map">
+            <Option type="int" value="2" name="source"/>
+            <Option type="QString" value="&quot;t_id&quot; &lt; &quot;t_id_2&quot;" name="static_value"/>
+          </Option>
+        </Option>
+        <Option type="List" name="INPUT">
+          <Option type="Map">
+            <Option type="QString" value="native:intersection_1" name="child_id"/>
+            <Option type="QString" value="OUTPUT" name="output_name"/>
+            <Option type="int" value="1" name="source"/>
+          </Option>
+        </Option>
+      </Option>
+    </Option>
+    <Option type="Map" name="native:extractbylocation_1">
+      <Option type="bool" value="true" name="active"/>
+      <Option name="alg_config"/>
+      <Option type="QString" value="native:extractbylocation" name="alg_id"/>
+      <Option type="QString" value="" name="color"/>
+      <Option type="Map" name="comment">
+        <Option type="QString" value="" name="color"/>
+        <Option type="QString" value="" name="component_description"/>
+        <Option type="double" value="60" name="component_height"/>
+        <Option type="double" value="1259.2177097203728" name="component_pos_x"/>
+        <Option type="double" value="504.76697736351537" name="component_pos_y"/>
+        <Option type="double" value="100" name="component_width"/>
+        <Option type="bool" value="true" name="outputs_collapsed"/>
+        <Option type="bool" value="true" name="parameters_collapsed"/>
+      </Option>
+      <Option type="QString" value="Extract by location" name="component_description"/>
+      <Option type="double" value="30" name="component_height"/>
+      <Option type="double" value="664.3059848729007" name="component_pos_x"/>
+      <Option type="double" value="396.0730622648059" name="component_pos_y"/>
+      <Option type="double" value="200" name="component_width"/>
+      <Option name="dependencies"/>
+      <Option type="QString" value="native:extractbylocation_1" name="id"/>
+      <Option name="outputs"/>
+      <Option type="bool" value="true" name="outputs_collapsed"/>
+      <Option type="bool" value="true" name="parameters_collapsed"/>
+      <Option type="Map" name="params">
+        <Option type="List" name="INPUT">
+          <Option type="Map">
+            <Option type="QString" value="native:createspatialindex_1" name="child_id"/>
+            <Option type="QString" value="OUTPUT" name="output_name"/>
+            <Option type="int" value="1" name="source"/>
+          </Option>
+        </Option>
+        <Option type="List" name="INTERSECT">
+          <Option type="Map">
+            <Option type="QString" value="native:extractbyexpression_1" name="child_id"/>
+            <Option type="QString" value="OUTPUT" name="output_name"/>
+            <Option type="int" value="1" name="source"/>
+          </Option>
+        </Option>
+        <Option type="List" name="PREDICATE">
+          <Option type="Map">
+            <Option type="int" value="2" name="source"/>
+            <Option type="List" name="static_value">
+              <Option type="int" value="2"/>
+            </Option>
           </Option>
         </Option>
       </Option>
     </Option>
     <Option type="Map" name="native:intersection_1">
-      <Option value="true" type="bool" name="active"/>
+      <Option type="bool" value="true" name="active"/>
       <Option name="alg_config"/>
-      <Option value="native:intersection" type="QString" name="alg_id"/>
-      <Option value="Lines_intersect" type="QString" name="component_description"/>
-      <Option value="170" type="double" name="component_pos_x"/>
-      <Option value="222" type="double" name="component_pos_y"/>
+      <Option type="QString" value="native:intersection" name="alg_id"/>
+      <Option type="QString" value="" name="color"/>
+      <Option type="Map" name="comment">
+        <Option type="QString" value="" name="color"/>
+        <Option type="QString" value="" name="component_description"/>
+        <Option type="double" value="30" name="component_height"/>
+        <Option type="double" value="0" name="component_pos_x"/>
+        <Option type="double" value="0" name="component_pos_y"/>
+        <Option type="double" value="200" name="component_width"/>
+        <Option type="bool" value="false" name="outputs_collapsed"/>
+        <Option type="bool" value="false" name="parameters_collapsed"/>
+      </Option>
+      <Option type="QString" value="Lines_intersect" name="component_description"/>
+      <Option type="double" value="30" name="component_height"/>
+      <Option type="double" value="243.3301483508008" name="component_pos_x"/>
+      <Option type="double" value="248.2571662106982" name="component_pos_y"/>
+      <Option type="double" value="200" name="component_width"/>
       <Option name="dependencies"/>
-      <Option value="native:intersection_1" type="QString" name="id"/>
+      <Option type="QString" value="native:intersection_1" name="id"/>
       <Option name="outputs"/>
-      <Option value="true" type="bool" name="outputs_collapsed"/>
-      <Option value="true" type="bool" name="parameters_collapsed"/>
+      <Option type="bool" value="true" name="outputs_collapsed"/>
+      <Option type="bool" value="true" name="parameters_collapsed"/>
       <Option type="Map" name="params">
         <Option type="List" name="INPUT">
           <Option type="Map">
-            <Option value="Boundary" type="QString" name="parameter_name"/>
-            <Option value="0" type="int" name="source"/>
+            <Option type="QString" value="Boundary" name="parameter_name"/>
+            <Option type="int" value="0" name="source"/>
           </Option>
         </Option>
         <Option type="List" name="INPUT_FIELDS">
           <Option type="Map">
-            <Option value="2" type="int" name="source"/>
-            <Option value="" type="Unknown" name="static_value"/>
+            <Option type="int" value="2" name="source"/>
+            <Option type="invalid" name="static_value"/>
           </Option>
         </Option>
         <Option type="List" name="OVERLAY">
           <Option type="Map">
-            <Option value="Boundary" type="QString" name="parameter_name"/>
-            <Option value="0" type="int" name="source"/>
+            <Option type="QString" value="Boundary" name="parameter_name"/>
+            <Option type="int" value="0" name="source"/>
           </Option>
         </Option>
         <Option type="List" name="OVERLAY_FIELDS">
           <Option type="Map">
-            <Option value="2" type="int" name="source"/>
-            <Option value="" type="Unknown" name="static_value"/>
+            <Option type="int" value="2" name="source"/>
+            <Option type="invalid" name="static_value"/>
           </Option>
         </Option>
       </Option>
     </Option>
     <Option type="Map" name="native:intersection_2">
-      <Option value="true" type="bool" name="active"/>
+      <Option type="bool" value="true" name="active"/>
       <Option name="alg_config"/>
-      <Option value="native:intersection" type="QString" name="alg_id"/>
-      <Option value="Intersection_vertices" type="QString" name="component_description"/>
-      <Option value="729" type="double" name="component_pos_x"/>
-      <Option value="182" type="double" name="component_pos_y"/>
+      <Option type="QString" value="native:intersection" name="alg_id"/>
+      <Option type="QString" value="" name="color"/>
+      <Option type="Map" name="comment">
+        <Option type="QString" value="" name="color"/>
+        <Option type="QString" value="" name="component_description"/>
+        <Option type="double" value="30" name="component_height"/>
+        <Option type="double" value="929" name="component_pos_x"/>
+        <Option type="double" value="137" name="component_pos_y"/>
+        <Option type="double" value="200" name="component_width"/>
+        <Option type="bool" value="true" name="outputs_collapsed"/>
+        <Option type="bool" value="true" name="parameters_collapsed"/>
+      </Option>
+      <Option type="QString" value="Intersection_vertices" name="component_description"/>
+      <Option type="double" value="30" name="component_height"/>
+      <Option type="double" value="777.0454697775358" name="component_pos_x"/>
+      <Option type="double" value="244.23920879572907" name="component_pos_y"/>
+      <Option type="double" value="200" name="component_width"/>
       <Option name="dependencies"/>
-      <Option value="native:intersection_2" type="QString" name="id"/>
+      <Option type="QString" value="native:intersection_2" name="id"/>
       <Option name="outputs"/>
-      <Option value="true" type="bool" name="outputs_collapsed"/>
-      <Option value="true" type="bool" name="parameters_collapsed"/>
+      <Option type="bool" value="true" name="outputs_collapsed"/>
+      <Option type="bool" value="true" name="parameters_collapsed"/>
       <Option type="Map" name="params">
         <Option type="List" name="INPUT">
           <Option type="Map">
-            <Option value="qgis:extractspecificvertices_1" type="QString" name="child_id"/>
-            <Option value="OUTPUT" type="QString" name="output_name"/>
-            <Option value="1" type="int" name="source"/>
+            <Option type="QString" value="qgis:extractspecificvertices_1" name="child_id"/>
+            <Option type="QString" value="OUTPUT" name="output_name"/>
+            <Option type="int" value="1" name="source"/>
           </Option>
         </Option>
         <Option type="List" name="INPUT_FIELDS">
           <Option type="Map">
-            <Option value="2" type="int" name="source"/>
-            <Option value="" type="Unknown" name="static_value"/>
+            <Option type="int" value="2" name="source"/>
+            <Option type="StringList" name="static_value">
+              <Option type="QString" value="t_id"/>
+              <Option type="QString" value="t_ili_tid"/>
+            </Option>
           </Option>
         </Option>
         <Option type="List" name="OVERLAY">
           <Option type="Map">
-            <Option value="qgis:extractspecificvertices_1" type="QString" name="child_id"/>
-            <Option value="OUTPUT" type="QString" name="output_name"/>
-            <Option value="1" type="int" name="source"/>
+            <Option type="QString" value="qgis:extractspecificvertices_1" name="child_id"/>
+            <Option type="QString" value="OUTPUT" name="output_name"/>
+            <Option type="int" value="1" name="source"/>
           </Option>
         </Option>
         <Option type="List" name="OVERLAY_FIELDS">
           <Option type="Map">
-            <Option value="2" type="int" name="source"/>
-            <Option value="" type="Unknown" name="static_value"/>
+            <Option type="int" value="2" name="source"/>
+            <Option type="StringList" name="static_value">
+              <Option type="QString" value="t_id"/>
+              <Option type="QString" value="t_ili_tid"/>
+            </Option>
+          </Option>
+        </Option>
+        <Option type="List" name="OVERLAY_FIELDS_PREFIX">
+          <Option type="Map">
+            <Option type="int" value="2" name="source"/>
+            <Option type="QString" value="" name="static_value"/>
           </Option>
         </Option>
       </Option>
     </Option>
     <Option type="Map" name="native:lineintersections_1">
-      <Option value="true" type="bool" name="active"/>
+      <Option type="bool" value="true" name="active"/>
       <Option name="alg_config"/>
-      <Option value="native:lineintersections" type="QString" name="alg_id"/>
-      <Option value="point_intersections" type="QString" name="component_description"/>
-      <Option value="507" type="double" name="component_pos_x"/>
-      <Option value="283" type="double" name="component_pos_y"/>
+      <Option type="QString" value="native:lineintersections" name="alg_id"/>
+      <Option type="QString" value="" name="color"/>
+      <Option type="Map" name="comment">
+        <Option type="QString" value="" name="color"/>
+        <Option type="QString" value="" name="component_description"/>
+        <Option type="double" value="30" name="component_height"/>
+        <Option type="double" value="707" name="component_pos_x"/>
+        <Option type="double" value="238" name="component_pos_y"/>
+        <Option type="double" value="200" name="component_width"/>
+        <Option type="bool" value="true" name="outputs_collapsed"/>
+        <Option type="bool" value="true" name="parameters_collapsed"/>
+      </Option>
+      <Option type="QString" value="point_intersections" name="component_description"/>
+      <Option type="double" value="30" name="component_height"/>
+      <Option type="double" value="541.4306428534702" name="component_pos_x"/>
+      <Option type="double" value="242.15551922780276" name="component_pos_y"/>
+      <Option type="double" value="200" name="component_width"/>
       <Option name="dependencies"/>
-      <Option value="native:lineintersections_1" type="QString" name="id"/>
+      <Option type="QString" value="native:lineintersections_1" name="id"/>
       <Option name="outputs"/>
-      <Option value="true" type="bool" name="outputs_collapsed"/>
-      <Option value="true" type="bool" name="parameters_collapsed"/>
+      <Option type="bool" value="true" name="outputs_collapsed"/>
+      <Option type="bool" value="true" name="parameters_collapsed"/>
       <Option type="Map" name="params">
         <Option type="List" name="INPUT">
           <Option type="Map">
-            <Option value="Boundary" type="QString" name="parameter_name"/>
-            <Option value="0" type="int" name="source"/>
+            <Option type="QString" value="Boundary" name="parameter_name"/>
+            <Option type="int" value="0" name="source"/>
           </Option>
         </Option>
         <Option type="List" name="INPUT_FIELDS">
           <Option type="Map">
-            <Option value="2" type="int" name="source"/>
-            <Option value="" type="Unknown" name="static_value"/>
+            <Option type="int" value="2" name="source"/>
+            <Option type="StringList" name="static_value">
+              <Option type="QString" value="t_id"/>
+              <Option type="QString" value="t_ili_tid"/>
+              <Option type="QString" value="t_id_2"/>
+              <Option type="QString" value="t_ili_tid_2"/>
+            </Option>
           </Option>
         </Option>
         <Option type="List" name="INTERSECT">
           <Option type="Map">
-            <Option value="Boundary" type="QString" name="parameter_name"/>
-            <Option value="0" type="int" name="source"/>
+            <Option type="QString" value="Boundary" name="parameter_name"/>
+            <Option type="int" value="0" name="source"/>
           </Option>
         </Option>
         <Option type="List" name="INTERSECT_FIELDS">
           <Option type="Map">
-            <Option value="2" type="int" name="source"/>
-            <Option value="" type="Unknown" name="static_value"/>
+            <Option type="int" value="2" name="source"/>
+            <Option type="StringList" name="static_value">
+              <Option type="QString" value="t_id"/>
+              <Option type="QString" value="t_ili_tid"/>
+              <Option type="QString" value="t_id_2"/>
+              <Option type="QString" value="t_ili_tid_2"/>
+            </Option>
           </Option>
         </Option>
-      </Option>
-    </Option>
-    <Option type="Map" name="native:saveselectedfeatures_1">
-      <Option value="true" type="bool" name="active"/>
-      <Option name="alg_config"/>
-      <Option value="native:saveselectedfeatures" type="QString" name="alg_id"/>
-      <Option value="Save Selected Features" type="QString" name="component_description"/>
-      <Option value="1023" type="double" name="component_pos_x"/>
-      <Option value="425" type="double" name="component_pos_y"/>
-      <Option name="dependencies"/>
-      <Option value="native:saveselectedfeatures_1" type="QString" name="id"/>
-      <Option name="outputs"/>
-      <Option value="true" type="bool" name="outputs_collapsed"/>
-      <Option value="true" type="bool" name="parameters_collapsed"/>
-      <Option type="Map" name="params">
-        <Option type="List" name="INPUT">
+        <Option type="List" name="INTERSECT_FIELDS_PREFIX">
           <Option type="Map">
-            <Option value="qgis:selectbyexpression_2" type="QString" name="child_id"/>
-            <Option value="OUTPUT" type="QString" name="output_name"/>
-            <Option value="1" type="int" name="source"/>
-          </Option>
-        </Option>
-      </Option>
-    </Option>
-    <Option type="Map" name="native:saveselectedfeatures_2">
-      <Option value="true" type="bool" name="active"/>
-      <Option name="alg_config"/>
-      <Option value="native:saveselectedfeatures" type="QString" name="alg_id"/>
-      <Option value="Save Selected Features" type="QString" name="component_description"/>
-      <Option value="418" type="double" name="component_pos_x"/>
-      <Option value="513" type="double" name="component_pos_y"/>
-      <Option name="dependencies"/>
-      <Option value="native:saveselectedfeatures_2" type="QString" name="id"/>
-      <Option type="Map" name="outputs">
-        <Option type="Map" name="Intersected_Lines">
-          <Option value="native:saveselectedfeatures_2" type="QString" name="child_id"/>
-          <Option value="Intersected_Lines" type="QString" name="component_description"/>
-          <Option value="540" type="double" name="component_pos_x"/>
-          <Option value="658" type="double" name="component_pos_y"/>
-          <Option value="Intersected_Lines" type="QString" name="name"/>
-          <Option value="OUTPUT" type="QString" name="output_name"/>
-        </Option>
-      </Option>
-      <Option value="true" type="bool" name="outputs_collapsed"/>
-      <Option value="true" type="bool" name="parameters_collapsed"/>
-      <Option type="Map" name="params">
-        <Option type="List" name="INPUT">
-          <Option type="Map">
-            <Option value="qgis:selectbyexpression_1" type="QString" name="child_id"/>
-            <Option value="OUTPUT" type="QString" name="output_name"/>
-            <Option value="1" type="int" name="source"/>
-          </Option>
-        </Option>
-      </Option>
-    </Option>
-    <Option type="Map" name="native:saveselectedfeatures_3">
-      <Option value="true" type="bool" name="active"/>
-      <Option name="alg_config"/>
-      <Option value="native:saveselectedfeatures" type="QString" name="alg_id"/>
-      <Option value="Save Selected Features" type="QString" name="component_description"/>
-      <Option value="1032" type="double" name="component_pos_x"/>
-      <Option value="791" type="double" name="component_pos_y"/>
-      <Option name="dependencies"/>
-      <Option value="native:saveselectedfeatures_3" type="QString" name="id"/>
-      <Option type="Map" name="outputs">
-        <Option type="Map" name="Intersected_Points">
-          <Option value="native:saveselectedfeatures_3" type="QString" name="child_id"/>
-          <Option value="Intersected_Points" type="QString" name="component_description"/>
-          <Option value="1181" type="double" name="component_pos_x"/>
-          <Option value="876" type="double" name="component_pos_y"/>
-          <Option value="Intersected_Points" type="QString" name="name"/>
-          <Option value="OUTPUT" type="QString" name="output_name"/>
-        </Option>
-      </Option>
-      <Option value="true" type="bool" name="outputs_collapsed"/>
-      <Option value="true" type="bool" name="parameters_collapsed"/>
-      <Option type="Map" name="params">
-        <Option type="List" name="INPUT">
-          <Option type="Map">
-            <Option value="qgis:selectbyexpression_3" type="QString" name="child_id"/>
-            <Option value="OUTPUT" type="QString" name="output_name"/>
-            <Option value="1" type="int" name="source"/>
+            <Option type="int" value="2" name="source"/>
+            <Option type="QString" value="" name="static_value"/>
           </Option>
         </Option>
       </Option>
     </Option>
     <Option type="Map" name="qgis:extractspecificvertices_1">
-      <Option value="true" type="bool" name="active"/>
+      <Option type="bool" value="true" name="active"/>
       <Option name="alg_config"/>
-      <Option value="qgis:extractspecificvertices" type="QString" name="alg_id"/>
-      <Option value="Extract specific vertices" type="QString" name="component_description"/>
-      <Option value="455" type="double" name="component_pos_x"/>
-      <Option value="75" type="double" name="component_pos_y"/>
+      <Option type="QString" value="qgis:extractspecificvertices" name="alg_id"/>
+      <Option type="QString" value="" name="color"/>
+      <Option type="Map" name="comment">
+        <Option type="QString" value="" name="color"/>
+        <Option type="QString" value="" name="component_description"/>
+        <Option type="double" value="30" name="component_height"/>
+        <Option type="double" value="0" name="component_pos_x"/>
+        <Option type="double" value="0" name="component_pos_y"/>
+        <Option type="double" value="200" name="component_width"/>
+        <Option type="bool" value="false" name="outputs_collapsed"/>
+        <Option type="bool" value="false" name="parameters_collapsed"/>
+      </Option>
+      <Option type="QString" value="Extract specific vertices" name="component_description"/>
+      <Option type="double" value="30" name="component_height"/>
+      <Option type="double" value="674.203293965791" name="component_pos_x"/>
+      <Option type="double" value="139.18418407059562" name="component_pos_y"/>
+      <Option type="double" value="200" name="component_width"/>
       <Option name="dependencies"/>
-      <Option value="qgis:extractspecificvertices_1" type="QString" name="id"/>
+      <Option type="QString" value="qgis:extractspecificvertices_1" name="id"/>
       <Option name="outputs"/>
-      <Option value="true" type="bool" name="outputs_collapsed"/>
-      <Option value="true" type="bool" name="parameters_collapsed"/>
+      <Option type="bool" value="true" name="outputs_collapsed"/>
+      <Option type="bool" value="true" name="parameters_collapsed"/>
       <Option type="Map" name="params">
         <Option type="List" name="INPUT">
           <Option type="Map">
-            <Option value="Boundary" type="QString" name="parameter_name"/>
-            <Option value="0" type="int" name="source"/>
+            <Option type="QString" value="Boundary" name="parameter_name"/>
+            <Option type="int" value="0" name="source"/>
           </Option>
         </Option>
         <Option type="List" name="VERTICES">
           <Option type="Map">
-            <Option value="2" type="int" name="source"/>
-            <Option value="0,-1" type="QString" name="static_value"/>
-          </Option>
-        </Option>
-      </Option>
-    </Option>
-    <Option type="Map" name="qgis:selectbyexpression_1">
-      <Option value="true" type="bool" name="active"/>
-      <Option name="alg_config"/>
-      <Option value="qgis:selectbyexpression" type="QString" name="alg_id"/>
-      <Option value="lines_filtered" type="QString" name="component_description"/>
-      <Option value="243" type="double" name="component_pos_x"/>
-      <Option value="367" type="double" name="component_pos_y"/>
-      <Option name="dependencies"/>
-      <Option value="qgis:selectbyexpression_1" type="QString" name="id"/>
-      <Option name="outputs"/>
-      <Option value="true" type="bool" name="outputs_collapsed"/>
-      <Option value="true" type="bool" name="parameters_collapsed"/>
-      <Option type="Map" name="params">
-        <Option type="List" name="EXPRESSION">
-          <Option type="Map">
-            <Option value="2" type="int" name="source"/>
-            <Option value="&quot;t_id&quot; &lt; &quot;t_id_2&quot;" type="QString" name="static_value"/>
-          </Option>
-        </Option>
-        <Option type="List" name="INPUT">
-          <Option type="Map">
-            <Option value="native:intersection_1" type="QString" name="child_id"/>
-            <Option value="OUTPUT" type="QString" name="output_name"/>
-            <Option value="1" type="int" name="source"/>
-          </Option>
-        </Option>
-        <Option type="List" name="METHOD">
-          <Option type="Map">
-            <Option value="2" type="int" name="source"/>
-            <Option value="0" type="int" name="static_value"/>
-          </Option>
-        </Option>
-      </Option>
-    </Option>
-    <Option type="Map" name="qgis:selectbyexpression_2">
-      <Option value="true" type="bool" name="active"/>
-      <Option name="alg_config"/>
-      <Option value="qgis:selectbyexpression" type="QString" name="alg_id"/>
-      <Option value="Select by expression" type="QString" name="component_description"/>
-      <Option value="969" type="double" name="component_pos_x"/>
-      <Option value="274" type="double" name="component_pos_y"/>
-      <Option name="dependencies"/>
-      <Option value="qgis:selectbyexpression_2" type="QString" name="id"/>
-      <Option name="outputs"/>
-      <Option value="true" type="bool" name="outputs_collapsed"/>
-      <Option value="true" type="bool" name="parameters_collapsed"/>
-      <Option type="Map" name="params">
-        <Option type="List" name="EXPRESSION">
-          <Option type="Map">
-            <Option value="2" type="int" name="source"/>
-            <Option value="&quot;t_id&quot; &lt; &quot;t_id_2&quot;" type="QString" name="static_value"/>
-          </Option>
-        </Option>
-        <Option type="List" name="INPUT">
-          <Option type="Map">
-            <Option value="native:intersection_2" type="QString" name="child_id"/>
-            <Option value="OUTPUT" type="QString" name="output_name"/>
-            <Option value="1" type="int" name="source"/>
-          </Option>
-        </Option>
-        <Option type="List" name="METHOD">
-          <Option type="Map">
-            <Option value="2" type="int" name="source"/>
-            <Option value="0" type="int" name="static_value"/>
-          </Option>
-        </Option>
-      </Option>
-    </Option>
-    <Option type="Map" name="qgis:selectbyexpression_3">
-      <Option value="true" type="bool" name="active"/>
-      <Option name="alg_config"/>
-      <Option value="qgis:selectbyexpression" type="QString" name="alg_id"/>
-      <Option value="points_filtered" type="QString" name="component_description"/>
-      <Option value="891" type="double" name="component_pos_x"/>
-      <Option value="695" type="double" name="component_pos_y"/>
-      <Option name="dependencies"/>
-      <Option value="qgis:selectbyexpression_3" type="QString" name="id"/>
-      <Option name="outputs"/>
-      <Option value="true" type="bool" name="outputs_collapsed"/>
-      <Option value="true" type="bool" name="parameters_collapsed"/>
-      <Option type="Map" name="params">
-        <Option type="List" name="EXPRESSION">
-          <Option type="Map">
-            <Option value="2" type="int" name="source"/>
-            <Option value="&quot;t_id&quot; &lt; &quot;t_id_2&quot;" type="QString" name="static_value"/>
-          </Option>
-        </Option>
-        <Option type="List" name="INPUT">
-          <Option type="Map">
-            <Option value="native:difference_1" type="QString" name="child_id"/>
-            <Option value="OUTPUT" type="QString" name="output_name"/>
-            <Option value="1" type="int" name="source"/>
-          </Option>
-        </Option>
-        <Option type="List" name="METHOD">
-          <Option type="Map">
-            <Option value="2" type="int" name="source"/>
-            <Option value="0" type="int" name="static_value"/>
+            <Option type="int" value="2" name="source"/>
+            <Option type="QString" value="0,-1" name="static_value"/>
           </Option>
         </Option>
       </Option>
     </Option>
   </Option>
+  <Option type="Map" name="designerParameterValues">
+    <Option type="QString" value="Lindero_cdebc817_1723_4078_8e04_9dec57513f22" name="Boundary"/>
+    <Option type="bool" value="true" name="VERBOSE_LOG"/>
+    <Option type="QgsProcessingOutputLayerDefinition" name="native:extractbyexpression_2:Intersected_Points">
+      <Option type="Map">
+        <Option type="Map" name="create_options">
+          <Option type="QString" value="System" name="fileEncoding"/>
+        </Option>
+        <Option type="Map" name="sink">
+          <Option type="bool" value="true" name="active"/>
+          <Option type="int" value="1" name="type"/>
+          <Option type="QString" value="TEMPORARY_OUTPUT" name="val"/>
+        </Option>
+      </Option>
+    </Option>
+    <Option type="QgsProcessingOutputLayerDefinition" name="native:extractbyexpression_3:Intersected_Lines">
+      <Option type="Map">
+        <Option type="Map" name="create_options">
+          <Option type="QString" value="System" name="fileEncoding"/>
+        </Option>
+        <Option type="Map" name="sink">
+          <Option type="bool" value="true" name="active"/>
+          <Option type="int" value="1" name="type"/>
+          <Option type="QString" value="TEMPORARY_OUTPUT" name="val"/>
+        </Option>
+      </Option>
+    </Option>
+  </Option>
+  <Option name="groupBoxes"/>
   <Option name="help"/>
-  <Option value="LADM-COL" type="QString" name="model_group"/>
-  <Option value="Overlapping_Boundaries" type="QString" name="model_name"/>
+  <Option name="modelVariables"/>
+  <Option type="QString" value="LADM-COL" name="model_group"/>
+  <Option type="QString" value="Overlapping_Boundaries" name="model_name"/>
   <Option type="Map" name="parameterDefinitions">
     <Option type="Map" name="Boundary">
       <Option type="List" name="data_types">
-        <Option value="1" type="int"/>
+        <Option type="int" value="1"/>
       </Option>
-      <Option value="" type="Unknown" name="default"/>
-      <Option value="Boundary" type="QString" name="description"/>
-      <Option value="0" type="int" name="flags"/>
+      <Option type="invalid" name="default"/>
+      <Option type="invalid" name="defaultGui"/>
+      <Option type="QString" value="Boundary" name="description"/>
+      <Option type="int" value="0" name="flags"/>
+      <Option type="QString" value="" name="help"/>
       <Option name="metadata"/>
-      <Option value="Boundary" type="QString" name="name"/>
-      <Option value="vector" type="QString" name="parameter_type"/>
+      <Option type="QString" value="Boundary" name="name"/>
+      <Option type="QString" value="vector" name="parameter_type"/>
     </Option>
-    <Option type="Map" name="native:saveselectedfeatures_2:Intersected_Lines">
-      <Option value="true" type="bool" name="create_by_default"/>
-      <Option value="0" type="int" name="data_type"/>
-      <Option value="" type="Unknown" name="default"/>
-      <Option value="Intersected_Lines" type="QString" name="description"/>
-      <Option value="0" type="int" name="flags"/>
+    <Option type="Map" name="native:extractbyexpression_2:Intersected_Points">
+      <Option type="bool" value="true" name="create_by_default"/>
+      <Option type="int" value="-1" name="data_type"/>
+      <Option type="invalid" name="default"/>
+      <Option type="invalid" name="defaultGui"/>
+      <Option type="QString" value="Intersected_Points" name="description"/>
+      <Option type="int" value="0" name="flags"/>
+      <Option type="QString" value="" name="help"/>
       <Option name="metadata"/>
-      <Option value="native:saveselectedfeatures_2:Intersected_Lines" type="QString" name="name"/>
-      <Option value="sink" type="QString" name="parameter_type"/>
-      <Option value="true" type="bool" name="supports_non_file_outputs"/>
+      <Option type="QString" value="native:extractbyexpression_2:Intersected_Points" name="name"/>
+      <Option type="QString" value="sink" name="parameter_type"/>
+      <Option type="bool" value="false" name="supports_append"/>
+      <Option type="bool" value="true" name="supports_non_file_outputs"/>
     </Option>
-    <Option type="Map" name="native:saveselectedfeatures_3:Intersected_Points">
-      <Option value="true" type="bool" name="create_by_default"/>
-      <Option value="0" type="int" name="data_type"/>
-      <Option value="" type="Unknown" name="default"/>
-      <Option value="Intersected_Points" type="QString" name="description"/>
-      <Option value="0" type="int" name="flags"/>
+    <Option type="Map" name="native:extractbyexpression_3:Intersected_Lines">
+      <Option type="bool" value="true" name="create_by_default"/>
+      <Option type="int" value="-1" name="data_type"/>
+      <Option type="invalid" name="default"/>
+      <Option type="invalid" name="defaultGui"/>
+      <Option type="QString" value="Intersected_Lines" name="description"/>
+      <Option type="int" value="0" name="flags"/>
+      <Option type="QString" value="" name="help"/>
       <Option name="metadata"/>
-      <Option value="native:saveselectedfeatures_3:Intersected_Points" type="QString" name="name"/>
-      <Option value="sink" type="QString" name="parameter_type"/>
-      <Option value="true" type="bool" name="supports_non_file_outputs"/>
+      <Option type="QString" value="native:extractbyexpression_3:Intersected_Lines" name="name"/>
+      <Option type="QString" value="sink" name="parameter_type"/>
+      <Option type="bool" value="false" name="supports_append"/>
+      <Option type="bool" value="true" name="supports_non_file_outputs"/>
     </Option>
   </Option>
+  <Option name="parameterOrder"/>
   <Option type="Map" name="parameters">
     <Option type="Map" name="Boundary">
-      <Option value="Boundary" type="QString" name="component_description"/>
-      <Option value="107" type="double" name="component_pos_x"/>
-      <Option value="89" type="double" name="component_pos_y"/>
-      <Option value="Boundary" type="QString" name="name"/>
+      <Option type="QString" value="" name="color"/>
+      <Option type="Map" name="comment">
+        <Option type="QString" value="" name="color"/>
+        <Option type="QString" value="" name="component_description"/>
+        <Option type="double" value="30" name="component_height"/>
+        <Option type="double" value="0" name="component_pos_x"/>
+        <Option type="double" value="0" name="component_pos_y"/>
+        <Option type="double" value="200" name="component_width"/>
+        <Option type="bool" value="false" name="outputs_collapsed"/>
+        <Option type="bool" value="false" name="parameters_collapsed"/>
+      </Option>
+      <Option type="QString" value="Boundary" name="component_description"/>
+      <Option type="double" value="30" name="component_height"/>
+      <Option type="double" value="332.0382197903905" name="component_pos_x"/>
+      <Option type="double" value="110.39472802353187" name="component_pos_y"/>
+      <Option type="double" value="200" name="component_width"/>
+      <Option type="QString" value="Boundary" name="name"/>
+      <Option type="bool" value="false" name="outputs_collapsed"/>
+      <Option type="bool" value="false" name="parameters_collapsed"/>
     </Option>
   </Option>
 </Option>

--- a/asistente_ladm_col/logic/quality/line_quality_rules.py
+++ b/asistente_ladm_col/logic/quality/line_quality_rules.py
@@ -83,8 +83,8 @@ class LineQualityRules:
                                  "There are no boundaries to check for overlaps!"), Qgis.Warning)
 
             else:
-                points_intersected = overlapping['native:saveselectedfeatures_3:Intersected_Points']
-                lines_intersected = overlapping['native:saveselectedfeatures_2:Intersected_Lines']
+                points_intersected = overlapping['native:extractbyexpression_2:Intersected_Points']
+                lines_intersected = overlapping['native:extractbyexpression_3:Intersected_Lines']
 
                 if isinstance(points_intersected, QgsVectorLayer):
                     point_features = list()


### PR DESCRIPTION
It was broken due to a GEOS error 'difference failed' on QGIS 3.16+

 + [x] Waiting for the approval by the author of issue #421

Fix #421 