### PR TITLE
Corrección con la versión de PROJ v8

### DIFF
--- a/asistente_ladm_col/logic/ladm_col/config/queries/qgis/ctm12_queries.py
+++ b/asistente_ladm_col/logic/ladm_col/config/queries/qgis/ctm12_queries.py
@@ -1,5 +1,5 @@
 def get_ctm12_exists_query():
-    return "SELECT count(srid) FROM tbl_srs WHERE srid=9377 and auth_name='EPSG'"
+    return "SELECT count(srid) FROM tbl_srs WHERE auth_id=9377 and auth_name='EPSG'"
 
 
 def get_insert_ctm12_query():


### PR DESCRIPTION
Se registra el siguiente error en la versión de PROJ 8.

![image](https://user-images.githubusercontent.com/545152/122805176-649afd00-d28e-11eb-86a4-0bb44258af9b.png)

La corrección se realiza en la consulta del código EPSG:9377 en el campo *auth_id*.