### PR TITLE
[geometry] Skip NULL or EMPTY geometries while checking point overlaps

### DIFF
--- a/asistente_ladm_col/lib/geometry.py
+++ b/asistente_ladm_col/lib/geometry.py
@@ -245,6 +245,9 @@ class GeometryUtils(QObject):
 
         request = QgsFeatureRequest().setSubsetOfAttributes([])
         for feature in point_layer.getFeatures(request):
+            if feature.geometry().isEmpty():
+                continue  # Skip NULL or EMPTY geometries
+                
             if not feature.id() in set_points:
                 ids = index.intersects(feature.geometry().boundingBox())
 


### PR DESCRIPTION
Fix #461